### PR TITLE
Call Generated_code.init once by module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -478,8 +478,8 @@ world.opt: checknative
 # Compile ocamlc with bisect_ppx
 .PHONY: world.bisected
 world.bisected:
-	#rm typing/typetexp.cmo
-	rm `find . -name '*.cmo'`
+	rm typing/typetexp.cmo
+	# rm `find . -name '*.cmo'`
 	$(MAKE) -C bisect_ppx/src/runtime
 	$(MAKE) -C bisect_ppx/src/ppx
 	$(MAKE) PPX="-ppx ./bisect_ppx/src/ppx/bisect_ppx" CUSTOM="-custom" RUNTIME="-I bisect_ppx/src/runtime" ADDCMO="extension.cmo common.cmo runtime.cmo" ocamlc

--- a/bisect_ppx/src/ppx/instrument.ml
+++ b/bisect_ppx/src/ppx/instrument.ml
@@ -612,9 +612,12 @@ module Generated_code :
   end
 let super = Ast_mapper.default_mapper
 
-let instrument_expr = Generated_code.instrument_expr @@ Generated_code.init ()
-let instrument_class_field_kind = Generated_code.instrument_class_field_kind @@ Generated_code.init ()
-let instrument_case = Generated_code.instrument_case @@ Generated_code.init ()
+
+module Make() = struct
+let points = Generated_code.init ()
+let instrument_expr = Generated_code.instrument_expr @@ points
+let instrument_class_field_kind = Generated_code.instrument_class_field_kind @@ points
+let instrument_case = Generated_code.instrument_case @@ points
 
 let class_expr mapper ce =
   let loc = ce.pcl_loc in
@@ -787,7 +790,7 @@ let structure mapper ast =
         else
           (let instrumented_ast = super.structure mapper ast in
            let runtime_initialization =
-             Generated_code.runtime_initialization (Generated_code.init ())
+             Generated_code.runtime_initialization (points)
                (!Location.input_name) in
            runtime_initialization @ instrumented_ast)))
 let mapper =
@@ -802,3 +805,4 @@ let mapper =
     signature;
     structure
   }
+end

--- a/bisect_ppx/src/ppx/instrument.mli
+++ b/bisect_ppx/src/ppx/instrument.mli
@@ -9,4 +9,6 @@
 (**  This class implements an instrumenter to be used through the {i -ppx}
     command-line switch. *)
 
-val mapper : Ast_mapper.mapper
+module Make: functor() -> sig
+  val mapper : Ast_mapper.mapper
+end

--- a/bisect_ppx/src/ppx/register.ml
+++ b/bisect_ppx/src/ppx/register.ml
@@ -63,4 +63,7 @@ open Ppx_tools_405
 *)
 let () =
   Ast_mapper.register "bisect_ppx"
-    (fun _ -> Instrument.mapper)
+    (fun _ ->
+       let module M = Instrument.Make() in
+       M.mapper
+    )


### PR DESCRIPTION
Sharing the initialisation code seems to fix the out of bounds error.